### PR TITLE
dependabot: delete the empty `ignore` entry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    ignore:
     open-pull-requests-limit: 10


### PR DESCRIPTION
Fix Dependabot config